### PR TITLE
Allow using multiturn-chat

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,7 @@ __pycache__
 
 # Exclude Python virtual environment
 /venv
+.venv
+
+# Exclude model weights
+checkpoints

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This is an implementation of the Huggingface space [Apollo-LMMs/Apollo-7B-t32](https://huggingface.co/Apollo-LMMs/Apollo-7B-t32) as a Cog model. [Cog packages machine learning models as standard containers.](https://github.com/replicate/cog)
 
 Run a prediction:
-
-    cog predict -i video=@astro.mp4 -i prompt="Describe this video in detail"
+```bash
+cog predict -i video=@astro.mp4 -i messages='[{"role": "user", "content": "Describe this video in detail"}]'
+```
 
 ## Input
 
@@ -13,3 +14,19 @@ Run a prediction:
 ## Output:
 
     The video features an astronaut in a white spacesuit walking on the moon's surface. The background showcases a large, detailed moon against a starry sky. As the astronaut walks, they begin to run and eventually leap into the air, floating above the moon's rocky terrain. The scene transitions to the astronaut drifting away from the moon, with the lunar landscape and the moon itself visible in the background. The video concludes with the astronaut continuing to float in space, gazing at the moon.
+
+
+# Build & Run Locally (Docker)
+Build the container:
+```bash
+cog build -t replicate-apollo-7b
+```
+Download and unpack the model weights:
+```bash
+mkdir checkpoints
+cd checkpoints
+wget https://weights.replicate.delivery/default/Apollo-LMMs/Apollo-7B-t32/7b.tar
+tar -xvf 7b.tar
+```
+
+To get a prediction, run the command `cog predict` command above.

--- a/utils/openai_conversation.py
+++ b/utils/openai_conversation.py
@@ -1,0 +1,17 @@
+import json
+from typing import Literal
+from pydantic import BaseModel
+
+
+class Message(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+
+    @classmethod
+    def parse_messages(cls, messages: str):
+        return [cls(**msg) for msg in json.loads(messages)]
+
+
+if __name__ == "__main__":
+    conversation = '[{"role": "user", "content": "Hello, how are you?"}, {"role": "assistant", "content": "I\'m fine, thank you!"}, {"role": "user", "content": "What is your name?"}, {"role": "assistant", "content": "My name is Apollo."}]'
+    print(Message.parse_messages(conversation))


### PR DESCRIPTION
The user can have a multi-turn conversation with the model.
* I changed the interface of the model. Rather than a single `prompt`, it gets a list of `messages` as a JSON input. These `messages` are parsed into a full conversation. If we wanted to preserve the existing interface for backward compatibility, we could add `messages` as an optional parameter that overwrites the `prompt`.
* I tried using a pydantic model directly in the `predict()` method, but pydantic types are not yet allowed, so the function accepts `messages` as a string and parses it within the `predict()` method
* I removed the `cleanup()` method, because it seems unnecessary, but I have no strong opinions about this.